### PR TITLE
AUT-847

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,9 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/*.bat
+docs/reference/io/generated
+docs/reference/pathways/generated
 
 # PyBuilder
 target/

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,6 @@
+# .readthedocs.yml
+version: 2
+sphinx:
+   configuration: docs/conf.py
+conda:
+  environment: env.yml

--- a/BFAIR/io/database/mapping.py
+++ b/BFAIR/io/database/mapping.py
@@ -6,8 +6,7 @@ Contains basic functions to read, merge, and write FIA MS mapping files.
 __all__ = ["from_struct", "merge", "read", "write"]
 
 import csv
-from collections import namedtuple
-from collections.abc import Iterable
+from collections import Iterable, namedtuple
 
 import pandas as pd
 

--- a/BFAIR/io/database/struct.py
+++ b/BFAIR/io/database/struct.py
@@ -72,7 +72,7 @@ def from_products_dict(results, prefix="p"):
 
 def merge(struct_a, struct_b):
     """
-    Merges two mapping files.
+    Merges two struct files.
 
     Parameters
     ----------

--- a/BFAIR/io/model_factory.py
+++ b/BFAIR/io/model_factory.py
@@ -138,30 +138,42 @@ def create_model(model_name, thermo_data=None, lexicon=None, compartment_data=No
 models = _ModelFactory()
 """A factory class to load metabolic models.
 
-Example
--------
+Examples
+--------
+>>> from BFAIR.io import models
+
+Use the ``dir`` function to obtain a list of available models.
+
 >>> dir(models)
 ['iJO1366', 'small_ecoli', 'yeastGEM']
+
+Models can be loaded by accessing them as class attributes.
 
 >>> model = models.small_ecoli
 >>> model.slim_optimize()
 0.8109621653343296
 
-This is equivalent to ``BFAIR.io.load_cbm("small_ecoli")``.
+This is equivalent to ``load_cbm("small_ecoli")``.
 """
 
 
 thermo_models = _ThermoModelFactory()
 """A factory class to create pre-curated thermodynamics-based metabolic models.
 
-Example
--------
+Examples
+--------
+>>> from BFAIR.io import thermo_models
+
+Use the ``dir`` function to obtain a list of available models.
+
 >>> dir(models)
 ['iJO1366', 'small_ecoli']
+
+Models can be loaded by accessing them as class attributes.
 
 >>> tmodel = thermo_models.small_ecoli
 >>> tmodel.slim_optimize()
 0.8109972502600706
 
-This is equivalent to ``BFAIR.io.create_model("small_ecoli")``.
+This is equivalent to ``create_model("small_ecoli")``.
 """

--- a/BFAIR/pathways/rules.py
+++ b/BFAIR/pathways/rules.py
@@ -68,14 +68,18 @@ class RuleLibrary(AbstractContextManager):
     pathname : Path, optional
         Pathname to the reaction rule database. If it does not exist, the database will be downloaded into it.
     **kwargs
-        Standardization parameters applied to input compounds, see `BFAIR.pathways.standardization.standardize`.
-        Thorough standardization is enforced.
+        Standardization parameters applied to input compounds, see `BFAIR.pathways.utils.standardize`. Thorough
+        standardization is enforced.
 
     Attributes
     ----------
     available : pandas.DataFrame
         A dataframe with the available rules (after filters applied). It has columns for rule ID, associated MetaNetX
         ID, and SMARTS expression.
+
+    See Also
+    --------
+    utils.standardize
     """
 
     def __init__(self, pathname=None, **kwargs):

--- a/BFAIR/pathways/utils.py
+++ b/BFAIR/pathways/utils.py
@@ -22,7 +22,7 @@ def get_compound(input_compound, input_type="inchi", **kwargs) -> AllChem.Mol:
     input_type : {'inchi', 'smiles', 'rdkit'}
         Type of notation describing the input compound.
     **kwargs
-        Standardization parameters applied to the input compound, see `BFAIR.pathways.standardization.standardize`.
+        Standardization parameters applied to the input compound, see `standardize`.
 
     Returns
     -------
@@ -33,6 +33,10 @@ def get_compound(input_compound, input_type="inchi", **kwargs) -> AllChem.Mol:
     ------
     ValueError
         If an unsupported input type is supplied.
+
+    See Also
+    --------
+    standardize
     """
     if input_type == "inchi":
         compound = Chem.MolFromInchi(input_compound, sanitize=False)
@@ -59,12 +63,17 @@ def get_molecular_fingerprint(input_compound, input_type="inchi", **kwargs):
     input_type : {'inchi', 'smiles', 'rdkit'}
         Type of notation describing the input compound.
     **kwargs
-        Standardization parameters applied to the input compound, see `BFAIR.pathways.standardization.standardize`.
+        Standardization parameters applied to the input compound, see `standardize`.
 
     Returns
     -------
     list of int
         A molecular fingerprint, represented as a list of indexes corresponding to present substructural features.
+
+
+    See Also
+    --------
+    standardize
     """
     compound = get_compound(input_compound, input_type, **kwargs)
     return [

--- a/BFAIR/pathways/viz.py
+++ b/BFAIR/pathways/viz.py
@@ -5,7 +5,7 @@ Toolbox of functions to visualize results from the pathway debugging module.
 
 __all__ = ["plot_pathway"]
 
-from collections.abc import Iterable
+from collections import Iterable
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,48 @@
+# Configuration file for the Sphinx documentation builder.
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path("..").resolve()))
+
+# -- Project information -----------------------------------------------------
+
+project = 'BFAIR'
+copyright = '2021, AutoFlowResearch'
+author = 'AutoFlowResearch'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.1'
+
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    "sphinx.ext.autosummary",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "numpydoc",
+]
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+autosummary_generate = True
+numpydoc_show_class_members = False
+
+# -- Options for HTML output -------------------------------------------------
+
+html_title = "BFAIR"
+html_theme = 'sphinx_material'
+html_theme_options = {
+    "repo_url": "https://github.com/AutoFlowResearch/BFAIR",
+    "repo_name": "BFAIR",
+    "color_primary": "indigo",
+    "color_accent": "pink",
+    "globaltoc_depth": 3
+}
+html_sidebars = {
+    "**": ["globaltoc.html", "localtoc.html"]
+}
+html_static_path = ['_static']
+# html_css_files = ["style.css"]
+html_collapsible_definitions = True

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -1,0 +1,45 @@
+Contributor Guide
+=================
+
+We welcome all contributions.  Please follow the guidelines below when contributing code.
+
+Quickstart
+----------
+
+1. Fork the repository
+2. Clone the repository
+3. Make a new branch from `develop` (see git model below) with your feature or fix
+4. Submit a pull request
+
+Guidelines
+----------
+
+- Please use the `GitFlow model <https://datasift.github.io/gitflow/IntroducingGitFlow.html>`_.
+- Please use `Numpy docstrings <https://numpydoc.readthedocs.io/en/latest/format.html>`_.
+- Please use the following `standard prefixes for commit messages <https://www.conventionalcommits.org/en/v1.0.0/>`_:
+
+  - ``fix``: for all commits that deal with fixing an issue,
+  - ``feat``: for all commits that deal with adding a new feature,
+  - ``test``: for all commits that deal with unit testing,
+  - ``build``: for all commits that deal with the CI infrastructure and deployment,
+  - ``docs``: to identify documentation changes,
+  - ``perf``: to identify changes related to performance improvements,
+  - ``style``: to identify changes related to styling (e.g., indentations, semi-colons, quotes, etc.), and
+  - ``refactor``: for all commits that deal with changes in code that neither add or fix a feature (e.g., renaming
+    variables, simplifying codes, removing redundant code, etc.).
+
+- Please use the following PR title and description standards:
+
+  - The PR title should be short and descriptive.  Work in progress reviews should be titled as ``WIP:...`` and all
+    other should follow the above for commit messages.
+  - The PR description should describe 1) new features, 2) fixes, and 3) other changes.
+
+PR Acceptance Rules
+^^^^^^^^^^^^^^^^^^^
+
+In order to accept a PR, the following must be satisfied:
+
+1. All new functions and classes have corresponding unit tests.
+2. All new functions and classes are documented using the correct style.
+3. All unit tests, linting tests, and integration tests pass.
+4. All new code is reviewed and approved by a repository maintainer.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,23 @@
+BFAIR
+=====
+
+BFAIR (Big and :abbr:`FAIR (findable, accessible, interoperable, and reusable)` omics data handling) is an informatics pipeline for sample submission, metadata tracking, raw data
+processing, and results retrieval.
+
+Documentation
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+   install
+   reference/index
+   developer/index
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,0 +1,4 @@
+Getting Started
+===============
+
+BFAIR requires Python 3.6. The recommended installation method is `pip <https://pip.pypa.io/en/stable/>`_.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,0 +1,9 @@
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 2
+
+   introduction
+   io/index
+   pathways/index

--- a/docs/reference/introduction.rst
+++ b/docs/reference/introduction.rst
@@ -1,0 +1,5 @@
+Introduction
+============
+
+BFAIR provides classes and functions to handle omics data, methods to read/open databases for accurate mass search,
+routines to list off-target metabolites in heterologous pathways, and more.

--- a/docs/reference/io/database.rst
+++ b/docs/reference/io/database.rst
@@ -1,0 +1,87 @@
+Database
+========
+
+.. currentmodule:: BFAIR.io.database
+
+A metabolite database is represented by two types of files: a struct and
+a mapping. These databases are used in the annotation process ran by
+SmartPeak.
+
+Both files are in :abbr:`TSV (tab-separated values)` format. Functions
+to handle these files have to be imported from the ``io`` module.
+
+.. code-block::
+
+    >>> from BFAIR.io import struct, mapping
+
+Struct
+------
+
+Struct files contain 4 columns of metabolite ID, formula, SMILES, and
+InChI. Only the first two columns are used by SmartPeak, so the rest can be
+filled with placeholders. As in the example:
+
+.. code-block::
+
+    >>> struct_test = struct.read("struct_test.tsv")
+    >>> struct_test.head()
+    id      formula    unused_smiles    unused_inchi
+    ------  ---------  ---------------  --------------
+    glc__D  C6H12O6    smiles           inchi
+    gln__L  C5H10N2O3  smiles           inchi
+    glu__L  C5H9NO4    smiles           inchi
+    glx     C2H2O3     smiles           inchi
+    h2o     H2O        smiles           inchi
+
+
+Functions
+^^^^^^^^^
+
+The ``struct`` module contains functions to read, create, merge, and read
+struct files.
+
+.. autosummary::
+   :toctree: generated/
+
+   struct.from_inchis
+   struct.from_products_dict
+   struct.merge
+   struct.read
+   struct.rename_metabolites
+   struct.write
+
+Mapping
+-------
+
+A mapping file summarizes a struct file by grouping metabolites by their
+formula. These data structures contain 3 columns of mass, formula, and
+metabolite IDs. The mass column is unused, so it typically contains 0 as a
+placeholder.
+
+.. code-block::
+
+    >>> mapping_test = mapping.from_struct(struct_test)
+    >>> mapping_test.head()
+      unused_mass  formula        ids
+    -------------  -------------  --------
+                0  C10H14N5O7P    ['amp']
+                0  C10H15N5O10P2  ['adp']
+                0  C10H16N5O13P3  ['atp']
+                0  C21H28N7O14P2  ['nad']
+                0  C21H29N7O14P2  ['nadh']
+
+
+
+Functions
+^^^^^^^^^
+
+The ``mapping`` module contains functions to read, create, merge, and read
+mapping files.
+
+.. autosummary::
+   :toctree: generated/
+
+   mapping.from_struct
+   mapping.merge
+   mapping.read
+   mapping.write

--- a/docs/reference/io/index.rst
+++ b/docs/reference/io/index.rst
@@ -1,0 +1,8 @@
+I/O
+===
+
+.. toctree::
+   :maxdepth: 2
+
+   database
+   models

--- a/docs/reference/io/models.rst
+++ b/docs/reference/io/models.rst
@@ -1,0 +1,29 @@
+Metabolic models
+================
+
+.. currentmodule:: BFAIR.io.model_factory
+
+Factory classes
+---------------
+
+BFAIR contains pre-curated genome-scale metabolic models that can be accessed
+through the ``models`` or ``thermo_models`` classes.
+
+.. autodata:: models
+   :annotation:
+
+.. autodata:: thermo_models
+   :annotation:
+
+Functions
+---------
+
+Alternatively (and equivalently), one can manually load genome-scale models
+using the following functions:
+
+.. autosummary::
+   :toctree: generated/
+
+   load_cbm
+   load_data
+   create_model

--- a/docs/reference/pathways/index.rst
+++ b/docs/reference/pathways/index.rst
@@ -1,0 +1,8 @@
+Pathways
+========
+
+.. toctree::
+   :maxdepth: 2
+
+   rules
+   utils

--- a/docs/reference/pathways/rules.rst
+++ b/docs/reference/pathways/rules.rst
@@ -1,0 +1,56 @@
+Rule library
+============
+
+Overview
+--------
+
+.. currentmodule:: BFAIR.pathways
+.. autoclass:: RuleLibrary
+   :exclude-members:
+
+Methods
+-------
+
+Opening and closing the rule database
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``RuleLibrary`` object is an interface to a SQL database of reaction rules. Used as a context manager, the
+connection to the database is automatically established. However, if one desires so, it is also possible to manually
+open and close the database.
+
+.. autosummary::
+   :toctree: generated/
+
+   RuleLibrary.open
+   RuleLibrary.close
+
+Adding and removing filters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To obtain a subset of reaction rules to work with, there are several filters that can be applied to a ``RuleLibrary``.
+For instance, one can select the reactions that are only available in yeast or rules that have certain specificity.
+Multiple filters can be combined.
+
+.. autosummary::
+   :toctree: generated/
+
+   RuleLibrary.filter_by_compound
+   RuleLibrary.filter_by_diameter
+   RuleLibrary.filter_by_organism
+   RuleLibrary.filter_by_uncertainty
+   RuleLibrary.pop_filter
+   RuleLibrary.reset
+
+Applying reaction rules
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Finally, once a subset of rules has been selected, the reaction rules can be applied to a compound (typically a known
+intermediate from a heterologous pathway). This will produce a list of products that can stem from the input source.
+Further pruning over this list can produce a list of off-products that arise from unexpected promiscuous enzymatic
+activity.
+
+.. autosummary::
+   :toctree: generated/
+
+   RuleLibrary.apply_to
+   RuleLibrary.list_products

--- a/docs/reference/pathways/utils.rst
+++ b/docs/reference/pathways/utils.rst
@@ -1,0 +1,40 @@
+Utils
+=====
+
+.. currentmodule:: BFAIR.pathways.utils
+
+The utils module offers a toolbox to handle chemical compounds and calculate structural similarity scores between them.
+It must be manually imported:
+
+.. code-block::
+
+   >>> from BFAIR.pathways import utils
+
+Functions
+---------
+
+Handling chemical compounds
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With these functions, one can convert a string depection of a molecule (such as InChI or SMILES) into a RDKit molecule
+object. These molecules are standardized for the sake of cohesiveness.
+
+.. autosummary::
+   :toctree: generated/
+
+   get_compound
+   standardize
+
+Calculating chemical similarity
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A molecular fingerprint is a list of indices that represent substructural features of a chemical compound. They are
+useful tools to compare the similarities between two molecules. For instance, the algorithm used in the
+`calculate_similarity` routine uses the Tanimoto coefficient, which is the intersection of structural properties
+(indices) divided by their union.
+
+.. autosummary::
+   :toctree: generated/
+
+   calculate_similarity
+   get_molecular_fingerprint

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx==3.4.3
+git+https://github.com/bashtage/sphinx-material.git
+numpydoc>=1.1
+nb2plots>=0.6

--- a/env.yml
+++ b/env.yml
@@ -8,3 +8,4 @@ dependencies:
   - pip:
     - pytest
     - -r requirements.txt
+    - -r docs/requirements.txt


### PR DESCRIPTION
Also concerns AUT-844 and AUT-845

Sets up documentation configuration files and pages for the Pathways and I/O module.

Documentation can be viewed at [https://bfair.readthedocs.io/en/latest/](https://bfair.readthedocs.io/en/latest/).

Example for I/O module: https://bfair.readthedocs.io/en/latest/reference/io/database.html